### PR TITLE
Use "test" in after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
 - yarn test
 
 after_success:
-- "[[ $TRAVIS_PULL_REQUEST != 'false' ]] && npx semantic-release-github-pr || exit 0"
+- test $TRAVIS_PULL_REQUEST != "false" && npx semantic-release-github-pr
 
 before_deploy:
 - yarn build


### PR DESCRIPTION
Updates CI to use a `test` command rather than the "ternary" that returns `exit 0` … maybe Travis' `skip` is equivalent to `exit 0`?