### PR TITLE
Sharper pixels

### DIFF
--- a/src/app/experiments/02-resizing/main.css
+++ b/src/app/experiments/02-resizing/main.css
@@ -10,7 +10,12 @@ main {
 
 canvas {
   background: #000;
-  width: 100%;
-  height: 100%;
+  image-rendering: optimizeSpeed;
+  image-rendering: -moz-crisp-edges;
+  image-rendering: -o-crisp-edges;
+  image-rendering: -webkit-optimize-contrast;
+  image-rendering: optimize-contrast;
+  image-rendering: crisp-edges;
   image-rendering: pixelated;
+  -ms-interpolation-mode: nearest-neighbor;
 }

--- a/src/app/experiments/02-resizing/main.ts
+++ b/src/app/experiments/02-resizing/main.ts
@@ -1,6 +1,6 @@
 import './main.css';
 
-import { cos, sin, toRadians } from '@fartts/lib/math';
+import { ceil, cos, sin, toRadians } from '@fartts/lib/math';
 
 import frag from './shader.frag';
 import vert from './shader.vert';
@@ -12,7 +12,7 @@ const gl = c.getContext('webgl', {
   antialias: false,
 }) as WebGLRenderingContext;
 
-const scale = 20;
+const scale = 10;
 gl.clearColor(0, 0, 0, 1);
 
 enum WebGLShaderType {
@@ -93,17 +93,17 @@ let a = 0;
 let didResize = false;
 
 function draw(t: number) {
-  requestAnimationFrame(draw);
+  // requestAnimationFrame(draw);
 
   if (didResize) {
     const {
       innerHeight: height,
       innerWidth: width,
-      devicePixelRatio: dpr,
+      devicePixelRatio: dpr = 1,
     } = window;
 
-    c.width = (width * dpr) / scale;
-    c.height = (height * dpr) / scale;
+    c.width = ceil((width / scale) * dpr);
+    c.height = ceil((height / scale) * dpr);
     gl.viewport(0, 0, c.width, c.height);
 
     didResize = false;

--- a/src/app/experiments/02-resizing/main.ts
+++ b/src/app/experiments/02-resizing/main.ts
@@ -1,6 +1,6 @@
 import './main.css';
 
-import { ceil, cos, sin, toRadians } from '@fartts/lib/math';
+import { cos, sin, toRadians } from '@fartts/lib/math';
 
 import frag from './shader.frag';
 import vert from './shader.vert';
@@ -12,7 +12,6 @@ const gl = c.getContext('webgl', {
   antialias: false,
 }) as WebGLRenderingContext;
 
-const scale = 10;
 gl.clearColor(0, 0, 0, 1);
 
 enum WebGLShaderType {
@@ -92,19 +91,26 @@ const buffer = gl.createBuffer();
 let a = 0;
 let didResize = false;
 
+const { isInteger } = Number;
+
 function draw(t: number) {
   // requestAnimationFrame(draw);
 
   if (didResize) {
     const {
+      devicePixelRatio: dpr = 1,
       innerHeight: height,
       innerWidth: width,
-      devicePixelRatio: dpr = 1,
     } = window;
 
-    c.width = ceil((width / scale) * dpr);
-    c.height = ceil((height / scale) * dpr);
+    const scale = 0.1;
+
+    c.width = width * scale;
+    c.height = height * scale;
     gl.viewport(0, 0, c.width, c.height);
+
+    c.style.width = `${width}px`;
+    c.style.height = `${height}px`;
 
     didResize = false;
   }

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -6,6 +6,7 @@ export const {
   abs,
   acos,
   atan2,
+  ceil,
   cos,
   floor,
   hypot,


### PR DESCRIPTION
Compute styling, attempt to sharpen pixels, still doesn't look good in Safari (desktop or mobile)

See these bugs in WebKit's Bugzilla:

- https://bugs.webkit.org/show_bug.cgi?id=138291
- https://bugs.webkit.org/show_bug.cgi?id=138293