### PR TITLE
Only use factories

### DIFF
--- a/src/lib/vec/factories.test.ts
+++ b/src/lib/vec/factories.test.ts
@@ -1,18 +1,17 @@
-import Vector from '.';
 import { vec2, vec3, vec4 } from './factories';
 import { toArray } from './util';
 
 describe('@fartts/lib/vec/factories', () => {
   test.each`
-    args                    | error
-    ${[1, 2]}               | ${null}
-    ${[[3, 4]]}             | ${null}
-    ${[5, [6]]}             | ${null}
-    ${[new Vector([7, 8])]} | ${null}
-    ${[1]}                  | ${'not enough arguments'}
-    ${[[[9, 0]]]}           | ${'not enough arguments'}
-    ${[1, 2, 3]}            | ${'too many arguments'}
-    ${[[2, 3], 4]}          | ${'too many arguments'}
+    args            | error
+    ${[1, 2]}       | ${null}
+    ${[[3, 4]]}     | ${null}
+    ${[5, [6]]}     | ${null}
+    ${[vec2(7, 8)]} | ${null}
+    ${[1]}          | ${'not enough arguments'}
+    ${[[[9, 0]]]}   | ${'not enough arguments'}
+    ${[1, 2, 3]}    | ${'too many arguments'}
+    ${[[2, 3], 4]}  | ${'too many arguments'}
   `('vec2($args)', ({ args, error }) => {
     const components = args.reduce(toArray, []);
 
@@ -54,17 +53,17 @@ describe('@fartts/lib/vec/factories', () => {
   });
 
   test.each`
-    args                       | error
-    ${[1, 2, 3]}               | ${null}
-    ${[[3, 4, 5]]}             | ${null}
-    ${[5, [6, 7]]}             | ${null}
-    ${[new Vector([7, 8, 9])]} | ${null}
-    ${[1]}                     | ${'not enough arguments'}
-    ${[1, 2]}                  | ${'not enough arguments'}
-    ${[1, [2]]}                | ${'not enough arguments'}
-    ${[[[9, 0]]]}              | ${'not enough arguments'}
-    ${[1, 2, 3, 4]}            | ${'too many arguments'}
-    ${[[2, 3], 4, 5]}          | ${'too many arguments'}
+    args                 | error
+    ${[1, 2, 3]}         | ${null}
+    ${[[3, 4, 5]]}       | ${null}
+    ${[5, [6, 7]]}       | ${null}
+    ${[vec3([7, 8, 9])]} | ${null}
+    ${[1]}               | ${'not enough arguments'}
+    ${[1, 2]}            | ${'not enough arguments'}
+    ${[1, [2]]}          | ${'not enough arguments'}
+    ${[[[9, 0]]]}        | ${'not enough arguments'}
+    ${[1, 2, 3, 4]}      | ${'too many arguments'}
+    ${[[2, 3], 4, 5]}    | ${'too many arguments'}
   `('vec3($args)', ({ args, error }) => {
     const components = args.reduce(toArray, []);
 
@@ -108,17 +107,17 @@ describe('@fartts/lib/vec/factories', () => {
   });
 
   test.each`
-    args                           | error
-    ${[1, 2, 3, 4]}                | ${null}
-    ${[[3, 4, 5, 6]]}              | ${null}
-    ${[5, [6, 7], 8]}              | ${null}
-    ${[new Vector([7, 8, 9, 10])]} | ${null}
-    ${[1]}                         | ${'not enough arguments'}
-    ${[1, 2]}                      | ${'not enough arguments'}
-    ${[1, [2, 3]]}                 | ${'not enough arguments'}
-    ${[[[9, 0], 1]]}               | ${'not enough arguments'}
-    ${[1, 2, 3, 4, 5]}             | ${'too many arguments'}
-    ${[[1, 2, 3], 4, 5]}           | ${'too many arguments'}
+    args                     | error
+    ${[1, 2, 3, 4]}          | ${null}
+    ${[[3, 4, 5, 6]]}        | ${null}
+    ${[5, [6, 7], 8]}        | ${null}
+    ${[vec4([7, 8, 9, 10])]} | ${null}
+    ${[1]}                   | ${'not enough arguments'}
+    ${[1, 2]}                | ${'not enough arguments'}
+    ${[1, [2, 3]]}           | ${'not enough arguments'}
+    ${[[[9, 0], 1]]}         | ${'not enough arguments'}
+    ${[1, 2, 3, 4, 5]}       | ${'too many arguments'}
+    ${[[1, 2, 3], 4, 5]}     | ${'too many arguments'}
   `('vec4($args)', ({ args, error }) => {
     const components = args.reduce(toArray, []);
 

--- a/src/lib/vec/factories.ts
+++ b/src/lib/vec/factories.ts
@@ -31,7 +31,8 @@ function getSwizzled(target: Vector, prop: string): number | Vector {
   }
 
   const keys = prop.split('');
-  return factories[keys.length - 2](keys.map(k => getByKey(target, k)));
+  const factory = getFactory(keys.length);
+  return factory(keys.map(k => getByKey(target, k)));
 }
 
 /**
@@ -135,7 +136,13 @@ function createFactory<V extends Vector>(size: number): Factory<V> {
     new Proxy(createVector(size, args), handler) as V;
 }
 
-export const factories: [Factory<Vec2>, Factory<Vec3>, Factory<Vec4>] = [
+export function getFactory(
+  size: number,
+): Factory<Vec2> | Factory<Vec3> | Factory<Vec4> {
+  return factories[size - 2];
+}
+
+const factories: [Factory<Vec2>, Factory<Vec3>, Factory<Vec4>] = [
   createFactory<Vec2>(2),
   createFactory<Vec3>(3),
   createFactory<Vec4>(4),

--- a/src/lib/vec/factories.ts
+++ b/src/lib/vec/factories.ts
@@ -136,20 +136,17 @@ function createFactory<V extends Vector>(size: number): Factory<V> {
     new Proxy(createVector(size, args), handler) as V;
 }
 
+/**
+ * ## getFactory
+ *
+ * @export
+ * @param {number} size
+ * @returns {(Factory<Vec2> | Factory<Vec3> | Factory<Vec4>)}
+ */
 export function getFactory(
   size: number,
 ): Factory<Vec2> | Factory<Vec3> | Factory<Vec4> {
   return factories[size - 2];
-}
-
-export function getLeft(size: number): Vec2 | Vec3 | Vec4 {
-  const factory = getFactory(size);
-  return factory(1, ...new Array(size - 1).fill(0));
-}
-
-export function getZeros(size: number): Vec2 | Vec3 | Vec4 {
-  const factory = getFactory(size);
-  return factory(new Array(size).fill(0));
 }
 
 const factories: [Factory<Vec2>, Factory<Vec3>, Factory<Vec4>] = [
@@ -159,3 +156,29 @@ const factories: [Factory<Vec2>, Factory<Vec3>, Factory<Vec4>] = [
 ];
 
 export const [vec2, vec3, vec4] = factories;
+
+/**
+ * ## getLeft
+ *
+ * @export
+ * @param {number} size
+ * @returns {(Vec2 | Vec3 | Vec4)}
+ */
+export function getLeft(size: number): Vec2 | Vec3 | Vec4 {
+  const factory = getFactory(size);
+  const args = new Array(size - 1).fill(0);
+  return factory(1, ...args);
+}
+
+/**
+ * ## getZeros
+ *
+ * @export
+ * @param {number} size
+ * @returns {(Vec2 | Vec3 | Vec4)}
+ */
+export function getZeros(size: number): Vec2 | Vec3 | Vec4 {
+  const factory = getFactory(size);
+  const args = new Array(size).fill(0);
+  return factory(...args);
+}

--- a/src/lib/vec/factories.ts
+++ b/src/lib/vec/factories.ts
@@ -142,6 +142,16 @@ export function getFactory(
   return factories[size - 2];
 }
 
+export function getLeft(size: number): Vec2 | Vec3 | Vec4 {
+  const factory = getFactory(size);
+  return factory(1, ...new Array(size - 1).fill(0));
+}
+
+export function getZeros(size: number): Vec2 | Vec3 | Vec4 {
+  const factory = getFactory(size);
+  return factory(new Array(size).fill(0));
+}
+
 const factories: [Factory<Vec2>, Factory<Vec3>, Factory<Vec4>] = [
   createFactory<Vec2>(2),
   createFactory<Vec3>(3),

--- a/src/lib/vec/index.test.ts
+++ b/src/lib/vec/index.test.ts
@@ -13,32 +13,32 @@ describe('@fartts/lib/vec', () => {
     expect(() => new Vector(1, 2, 3, 4, 5)).not.toThrow();
   });
 
-  test('dot', () => {
+  test('get dot', () => {
     expect(v2.dot).toBe(8);
     expect(v3.dot).toBe(27);
     expect(v4.dot).toBe(64);
   });
 
-  test('get ρ', () => {
-    expect(v2.ρ).toBeCloseTo(hypot(...v2));
-    expect(v2.ρ).toBeCloseTo(sqrt(8));
+  test('get magnitude', () => {
+    expect(v2.magnitude).toBeCloseTo(hypot(...v2));
+    expect(v2.magnitude).toBeCloseTo(sqrt(8));
 
-    expect(v3.ρ).toBeCloseTo(hypot(...v3));
-    expect(v3.ρ).toBeCloseTo(sqrt(27));
+    expect(v3.magnitude).toBeCloseTo(hypot(...v3));
+    expect(v3.magnitude).toBeCloseTo(sqrt(27));
 
-    expect(v4.ρ).toBeCloseTo(hypot(...v4));
-    expect(v4.ρ).toBeCloseTo(sqrt(64));
+    expect(v4.magnitude).toBeCloseTo(hypot(...v4));
+    expect(v4.magnitude).toBeCloseTo(sqrt(64));
   });
 
-  test('get θ', () => {
-    expect(v2.θ).toBeCloseTo(π / 4);
-    expect(v2.θ).toBeCloseTo(toRadians(45));
+  test('get direction', () => {
+    expect(v2.direction).toBeCloseTo(π / 4);
+    expect(v2.direction).toBeCloseTo(toRadians(45));
 
-    expect(v3.θ).toBeCloseTo(π / 3.2885355431);
-    expect(v3.θ).toBeCloseTo(toRadians(54.735610317245346));
+    expect(v3.direction).toBeCloseTo(π / 3.2885355431);
+    expect(v3.direction).toBeCloseTo(toRadians(54.735610317245346));
 
-    expect(v4.θ).toBeCloseTo(π / 3);
-    expect(v4.θ).toBeCloseTo(toRadians(60));
+    expect(v4.direction).toBeCloseTo(π / 3);
+    expect(v4.direction).toBeCloseTo(toRadians(60));
   });
 
   test('toString', () => {

--- a/src/lib/vec/index.test.ts
+++ b/src/lib/vec/index.test.ts
@@ -11,14 +11,6 @@ describe('@fartts/lib/vec', () => {
     expect(() => new Vector()).not.toThrow();
     expect(() => new Vector(1)).not.toThrow();
     expect(() => new Vector(1, 2, 3, 4, 5)).not.toThrow();
-
-    expect(new Vector(2, 2).toString()).toEqual(v2.toString());
-    expect(new Vector(3, 3, 3).toString()).toEqual(v3.toString());
-    expect(new Vector(4, 4, 4, 4).toString()).toEqual(v4.toString());
-
-    expect(new Vector(v2, 3).toString()).toBe('vec3(2,2,3)');
-    expect(new Vector(v3, 4).toString()).toBe('vec4(3,3,3,4)');
-    expect(new Vector(v2.x, 3, v4.zw).toString()).toBe('vec4(2,3,4,4)');
   });
 
   test('dot', () => {

--- a/src/lib/vec/index.ts
+++ b/src/lib/vec/index.ts
@@ -1,4 +1,4 @@
-import { dot, ρ, θ } from './math';
+import { dot, magnitude, direction } from './math';
 import { Components } from './types';
 import { toArray } from './util';
 
@@ -27,7 +27,7 @@ export default class Vector extends Array<number> implements Iterable<number> {
   }
 
   /**
-   * ## dot
+   * ## get dot
    *
    * @readonly
    * @type {number}
@@ -38,25 +38,25 @@ export default class Vector extends Array<number> implements Iterable<number> {
   }
 
   /**
-   * ## ρ
+   * ## get magnitude
    *
    * @readonly
    * @type {number}
    * @memberof Vector
    */
-  public get ρ(): number {
-    return ρ(this);
+  public get magnitude(): number {
+    return magnitude(this);
   }
 
   /**
-   * get θ
+   * ## get direction
    *
    * @readonly
    * @type {number}
    * @memberof Vector
    */
-  public get θ(): number {
-    return θ(this);
+  public get direction(): number {
+    return direction(this);
   }
 
   /**

--- a/src/lib/vec/index.ts
+++ b/src/lib/vec/index.ts
@@ -11,18 +11,6 @@ import { toArray } from './util';
  * @implements {Iterable<number>}
  */
 export default class Vector extends Array<number> implements Iterable<number> {
-  public static readonly origin: [Vector, Vector, Vector] = [
-    new Vector(0, 0),
-    new Vector(0, 0, 0),
-    new Vector(0, 0, 0, 0),
-  ];
-
-  public static readonly left: [Vector, Vector, Vector] = [
-    new Vector(1, 0),
-    new Vector(1, 0, 0),
-    new Vector(1, 0, 0, 0),
-  ];
-
   /**
    * ## constructor
    *
@@ -68,7 +56,7 @@ export default class Vector extends Array<number> implements Iterable<number> {
    * @memberof Vector
    */
   public get θ(): number {
-    return θ(Vector.left[this.length - 2], this);
+    return θ(this);
   }
 
   /**

--- a/src/lib/vec/math.test.ts
+++ b/src/lib/vec/math.test.ts
@@ -1,5 +1,16 @@
 import { vec2, vec3, vec4, getLeft, getZeros } from './factories';
-import { dot, ρ, θ, clone, add, sub, mul, div, norm, lerp } from './math';
+import {
+  dot,
+  magnitude,
+  direction,
+  clone,
+  add,
+  sub,
+  mul,
+  div,
+  norm,
+  lerp,
+} from './math';
 import { hypot, sqrt, π, toRadians } from '../math';
 
 describe('@fartts/lib/vec/math', () => {
@@ -33,8 +44,8 @@ describe('@fartts/lib/vec/math', () => {
     ${v3} | ${hypot(...v3)}
     ${v4} | ${sqrt(64)}
     ${v4} | ${hypot(...v4)}
-  `('ρ($v) should be $result', ({ v, result }) => {
-    expect(ρ(v)).toBe(result);
+  `('magnitude($v) should be $result', ({ v, result }) => {
+    expect(magnitude(v)).toBe(result);
   });
 
   test.each`
@@ -48,8 +59,8 @@ describe('@fartts/lib/vec/math', () => {
     ${v3} | ${getLeft(v3.length)}  | ${toRadians(54.735610317245346)}
     ${v4} | ${getLeft(v4.length)}  | ${π / 3}
     ${v4} | ${getLeft(v4.length)}  | ${toRadians(60)}
-  `('θ($a, $b) should be $result', ({ a, b, result }) => {
-    expect(θ(a, b)).toBeCloseTo(result);
+  `('direction($a, $b) should be $result', ({ a, b, result }) => {
+    expect(direction(a, b)).toBeCloseTo(result);
   });
 
   test.each`

--- a/src/lib/vec/math.test.ts
+++ b/src/lib/vec/math.test.ts
@@ -1,11 +1,8 @@
-import Vector from '.';
-import { vec2, vec3, vec4 } from './factories';
+import { vec2, vec3, vec4, getLeft, getZeros } from './factories';
 import { dot, ρ, θ, clone, add, sub, mul, div, norm, lerp } from './math';
 import { hypot, sqrt, π, toRadians } from '../math';
 
 describe('@fartts/lib/vec/math', () => {
-  const { origin, left } = Vector;
-
   const v2 = vec2(2, 2);
   const v3 = vec3(3, 3, 3);
   const v4 = vec4(4, 4, 4, 4);
@@ -41,16 +38,16 @@ describe('@fartts/lib/vec/math', () => {
   });
 
   test.each`
-    a     | b            | result
-    ${v2} | ${origin[0]} | ${0}
-    ${v3} | ${origin[1]} | ${0}
-    ${v4} | ${origin[2]} | ${0}
-    ${v2} | ${left[0]}   | ${π / 4}
-    ${v2} | ${left[0]}   | ${toRadians(45)}
-    ${v3} | ${left[1]}   | ${π / 3.2885355431}
-    ${v3} | ${left[1]}   | ${toRadians(54.735610317245346)}
-    ${v4} | ${left[2]}   | ${π / 3}
-    ${v4} | ${left[2]}   | ${toRadians(60)}
+    a     | b                      | result
+    ${v2} | ${getZeros(v2.length)} | ${0}
+    ${v3} | ${getZeros(v3.length)} | ${0}
+    ${v4} | ${getZeros(v4.length)} | ${0}
+    ${v2} | ${getLeft(v2.length)}  | ${π / 4}
+    ${v2} | ${getLeft(v2.length)}  | ${toRadians(45)}
+    ${v3} | ${getLeft(v3.length)}  | ${π / 3.2885355431}
+    ${v3} | ${getLeft(v3.length)}  | ${toRadians(54.735610317245346)}
+    ${v4} | ${getLeft(v4.length)}  | ${π / 3}
+    ${v4} | ${getLeft(v4.length)}  | ${toRadians(60)}
   `('θ($a, $b) should be $result', ({ a, b, result }) => {
     expect(θ(a, b)).toBeCloseTo(result);
   });
@@ -125,13 +122,13 @@ describe('@fartts/lib/vec/math', () => {
   });
 
   test.each`
-    a     | b            | i                                   | result
-    ${v2} | ${origin[0]} | ${1 / 2}                            | ${'vec2(1,1)'}
-    ${v2} | ${origin[0]} | ${vec2(2, 3)}                       | ${'vec2(-2,-4)'}
-    ${v3} | ${origin[1]} | ${2 / 3}                            | ${'vec3(1,1,1)'}
-    ${v3} | ${origin[1]} | ${vec3(1 / 3, 1 / 4, 1 / 5)}        | ${'vec3(2,2.25,2.4)'}
-    ${v4} | ${origin[2]} | ${1 / 4}                            | ${'vec4(3,3,3,3)'}
-    ${v4} | ${origin[2]} | ${vec4(2 / 5, 1 / 3, 2 / 7, 3 / 8)} | ${'vec4(2.4,2.666666666666667,2.857142857142857,2.5)'}
+    a     | b                      | i                                   | result
+    ${v2} | ${getZeros(v2.length)} | ${1 / 2}                            | ${'vec2(1,1)'}
+    ${v2} | ${getZeros(v2.length)} | ${vec2(2, 3)}                       | ${'vec2(-2,-4)'}
+    ${v3} | ${getZeros(v3.length)} | ${2 / 3}                            | ${'vec3(1,1,1)'}
+    ${v3} | ${getZeros(v3.length)} | ${vec3(1 / 3, 1 / 4, 1 / 5)}        | ${'vec3(2,2.25,2.4)'}
+    ${v4} | ${getZeros(v4.length)} | ${1 / 4}                            | ${'vec4(3,3,3,3)'}
+    ${v4} | ${getZeros(v4.length)} | ${vec4(2 / 5, 1 / 3, 2 / 7, 3 / 8)} | ${'vec4(2.4,2.666666666666667,2.857142857142857,2.5)'}
   `('lerp($a, $b, $i) should be $result', ({ a, b, i, result }) => {
     expect(lerp(a, b, i).toString()).toEqual(result);
   });

--- a/src/lib/vec/math.ts
+++ b/src/lib/vec/math.ts
@@ -37,7 +37,10 @@ export function ρ(v: Vector): number {
  * @param {Vector} b
  * @returns {number}
  */
-export function θ(a: Vector, b: Vector): number {
+export function θ(
+  a: Vector,
+  b: Vector = getFactory(a.length)([1, ...new Array(a.length - 1).fill(0)]),
+): number {
   const ρa = ρ(a);
   const ρb = ρ(b);
 

--- a/src/lib/vec/math.ts
+++ b/src/lib/vec/math.ts
@@ -1,4 +1,5 @@
 import Vector from '.';
+import { getFactory } from './factories';
 import { acos, hypot, lerp as slerp } from '../math';
 import { validateOperands } from './util';
 
@@ -56,7 +57,8 @@ export function θ(a: Vector, b: Vector): number {
  * @returns {Vector}
  */
 export function clone(v: Vector): Vector {
-  return new Vector(v);
+  const factory = getFactory(v.length);
+  return factory(v);
 }
 
 /**
@@ -72,7 +74,8 @@ export function add(a: Vector, b: number | Vector): Vector {
     validateOperands('add', a, b);
   }
 
-  return new Vector(a.map(getAdd(b)));
+  const factory = getFactory(a.length);
+  return factory(a.map(getAdd(b)));
 }
 
 const getAdd = (b: number | Vector) =>
@@ -93,7 +96,8 @@ export function sub(a: Vector, b: number | Vector): Vector {
     validateOperands('sub', a, b);
   }
 
-  return new Vector(a.map(getSub(b)));
+  const factory = getFactory(a.length);
+  return factory(a.map(getSub(b)));
 }
 
 const getSub = (b: number | Vector) =>
@@ -114,7 +118,8 @@ export function mul(a: Vector, b: number | Vector): Vector {
     validateOperands('mul', a, b);
   }
 
-  return new Vector(a.map(getMul(b)));
+  const factory = getFactory(a.length);
+  return factory(a.map(getMul(b)));
 }
 
 const getMul = (b: number | Vector) =>
@@ -135,7 +140,8 @@ export function div(a: Vector, b: number | Vector): Vector {
     validateOperands('div', a, b);
   }
 
-  return new Vector(a.map(getDiv(b)));
+  const factory = getFactory(a.length);
+  return factory(a.map(getDiv(b)));
 }
 
 const getDiv = (b: number | Vector) =>
@@ -151,7 +157,8 @@ const getDiv = (b: number | Vector) =>
  * @returns {Vector}
  */
 export function norm(v: Vector): Vector {
-  return new Vector(div(v, v.ρ));
+  const factory = getFactory(v.length);
+  return factory(div(v, v.ρ));
 }
 
 /**
@@ -170,7 +177,8 @@ export function lerp(a: Vector, b: Vector, i: number | Vector): Vector {
     validateOperands('lerp', a, i);
   }
 
-  return new Vector(a.map(getLerp(b, i)));
+  const factory = getFactory(a.length);
+  return factory(a.map(getLerp(b, i)));
 }
 
 const getLerp = (b: Vector, i: number | Vector) =>

--- a/src/lib/vec/math.ts
+++ b/src/lib/vec/math.ts
@@ -1,5 +1,5 @@
 import Vector from '.';
-import { getFactory } from './factories';
+import { getFactory, getLeft } from './factories';
 import { acos, hypot, lerp as slerp } from '../math';
 import { validateOperands } from './util';
 
@@ -37,10 +37,7 @@ export function magnitude(v: Vector): number {
  * @param {Vector} b
  * @returns {number}
  */
-export function direction(
-  a: Vector,
-  b: Vector = getFactory(a.length)([1, ...new Array(a.length - 1).fill(0)]),
-): number {
+export function direction(a: Vector, b: Vector = getLeft(a.length)): number {
   const ρa = magnitude(a);
   const ρb = magnitude(b);
 

--- a/src/lib/vec/math.ts
+++ b/src/lib/vec/math.ts
@@ -17,32 +17,32 @@ export function dot(a: Vector, b: Vector): number {
 }
 
 /**
- * ## ρ
+ * ## magnitude
  *
  * @export
  * @param {Vector} v
  * @returns {number}
  */
-export function ρ(v: Vector): number {
+export function magnitude(v: Vector): number {
   // an alternative for later comparison
   // return sqrt(dot(v, v));
   return hypot(...v);
 }
 
 /**
- * ## θ
+ * ## direction
  *
  * @export
  * @param {Vector} a
  * @param {Vector} b
  * @returns {number}
  */
-export function θ(
+export function direction(
   a: Vector,
   b: Vector = getFactory(a.length)([1, ...new Array(a.length - 1).fill(0)]),
 ): number {
-  const ρa = ρ(a);
-  const ρb = ρ(b);
+  const ρa = magnitude(a);
+  const ρb = magnitude(b);
 
   if (ρa === 0 || ρb === 0) {
     // it looks like this is what WebGL does
@@ -161,7 +161,7 @@ const getDiv = (b: number | Vector) =>
  */
 export function norm(v: Vector): Vector {
   const factory = getFactory(v.length);
-  return factory(div(v, v.ρ));
+  return factory(div(v, v.magnitude));
 }
 
 /**

--- a/src/lib/vec/util/index.test.ts
+++ b/src/lib/vec/util/index.test.ts
@@ -1,15 +1,15 @@
-import Vector from '..';
+import { vec2, vec3, vec4 } from '../factories';
 import { toArray, validateKeys, validateRange, Validates } from '.';
 
 describe('@fartts/lib/vec/util', () => {
   test.each`
-    args                                     | result
-    ${[1]}                                   | ${[1]}
-    ${[1, [2]]}                              | ${[1, 2]}
-    ${[1, [2], new Vector(3, 4)]}            | ${[1, 2, 3, 4]}
-    ${[1, [2, 3], new Vector(4, 5, 6)]}      | ${[1, 2, 3, 4, 5, 6]}
-    ${[[7, [8]]]}                            | ${[7, [8]]}
-    ${[1, [2, [3]], new Vector(4, 5, 6, 7)]} | ${[1, 2, [3], 4, 5, 6, 7]}
+    args                               | result
+    ${[1]}                             | ${[1]}
+    ${[1, [2]]}                        | ${[1, 2]}
+    ${[1, [2], vec2(3, 4)]}            | ${[1, 2, 3, 4]}
+    ${[1, [2, 3], vec3(4, 5, 6)]}      | ${[1, 2, 3, 4, 5, 6]}
+    ${[[7, [8]]]}                      | ${[7, [8]]}
+    ${[1, [2, [3]], vec4(4, 5, 6, 7)]} | ${[1, 2, [3], 4, 5, 6, 7]}
   `(
     /* ^^ demonstrates that it doesn't work recursively, only 1 deep ^^ */
     'expect($arguments.reduce(toArray, [])).toEqual($result)',


### PR DESCRIPTION
Refactors `ρ, θ` to `magnitude, direction` and replaces (almost) all instances of `new Vector` with the appropriate factory function … also adds a `getFactory` helper and `getLeft` and `getZeros` helpers to get left-facing or origin vectors of the appropriate size for some calculations.