### PR TITLE
Uncomplicate TypeScript setup

### DIFF
--- a/src/app/lab/01-webgl/main.ts
+++ b/src/app/lab/01-webgl/main.ts
@@ -1,6 +1,6 @@
 import './main.css';
 
-import { cos, sin, toRadians } from '@fartts/lib/math';
+import { cos, sin, toRadians } from '../../../lib/math';
 
 const DEV = 'development';
 // const PROD = 'production';

--- a/src/app/lab/02-resizing/main.ts
+++ b/src/app/lab/02-resizing/main.ts
@@ -1,6 +1,6 @@
 import './main.css';
 
-import { cos, sin, toRadians } from '@fartts/lib/math';
+import { cos, sin, toRadians } from '../../../lib/math';
 
 import frag from './shader.frag';
 import vert from './shader.vert';

--- a/src/app/lab/03-periodicity/main.ts
+++ b/src/app/lab/03-periodicity/main.ts
@@ -5,7 +5,7 @@ import { link } from './program';
 
 import vert from './shader.vert';
 import frag from './shader.frag';
-import { cosWave, sinWave, WaveFunction } from '@fartts/lib/wave';
+import { cosWave, sinWave, WaveFunction } from '../../../lib/wave';
 
 // const { keys, getPrototypeOf } = Object;
 const { isInteger } = Number;

--- a/src/app/lab/04-vectors/main.ts
+++ b/src/app/lab/04-vectors/main.ts
@@ -1,10 +1,10 @@
-import { el } from '@fartts/lib/dom';
-import loop from '@fartts/lib/game/loop';
-import { random, sin, cos, ππ, round } from '@fartts/lib/math';
-import resize from '@fartts/lib/util/resize';
-import { vec2 } from '@fartts/lib/vec/factories';
-import { sub, mul, add, div } from '@fartts/lib/vec/math';
-import { Vec2 } from '@fartts/lib/vec/types';
+import { el } from '../../../lib/dom';
+import loop from '../../../lib/game/loop';
+import { random, sin, cos, ππ, round } from '../../../lib/math';
+import resize from '../../../lib/util/resize';
+import { vec2 } from '../../../lib/vec/factories';
+import { sub, mul, add, div } from '../../../lib/vec/math';
+import { Vec2 } from '../../../lib/vec/types';
 
 import './main.css';
 

--- a/src/lib/dom.test.ts
+++ b/src/lib/dom.test.ts
@@ -1,22 +1,24 @@
-import { el, on } from '@fartts/lib/dom';
+import { el, on } from './dom';
 
-test('el', () => {
-  const querySelectorSpy = jest.spyOn(document, 'querySelector');
-  const body = el('body');
+describe('@fartts/lib/dom', () => {
+  test('el', () => {
+    const querySelectorSpy = jest.spyOn(document, 'querySelector');
+    const body = el('body');
 
-  expect(querySelectorSpy).toHaveBeenCalledTimes(1);
-  expect(querySelectorSpy).toHaveBeenCalledWith('body');
-  expect(body).toBeInstanceOf(HTMLBodyElement);
-});
+    expect(querySelectorSpy).toHaveBeenCalledTimes(1);
+    expect(querySelectorSpy).toHaveBeenCalledWith('body');
+    expect(body).toBeInstanceOf(HTMLBodyElement);
+  });
 
-test('on', () => {
-  const addEventlistenerSpy = jest.spyOn(window, 'addEventListener');
-  const listener = jest.fn();
+  test('on', () => {
+    const addEventlistenerSpy = jest.spyOn(window, 'addEventListener');
+    const listener = jest.fn();
 
-  on('resize', listener);
-  window.dispatchEvent(new Event('resize'));
+    on('resize', listener);
+    window.dispatchEvent(new Event('resize'));
 
-  expect(addEventlistenerSpy).toHaveBeenCalledTimes(1);
-  expect(addEventlistenerSpy).toHaveBeenCalledWith('resize', listener);
-  expect(listener).toHaveBeenCalledTimes(1);
+    expect(addEventlistenerSpy).toHaveBeenCalledTimes(1);
+    expect(addEventlistenerSpy).toHaveBeenCalledWith('resize', listener);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/game/loop.test.ts
+++ b/src/lib/game/loop.test.ts
@@ -1,7 +1,7 @@
 import loop, { stepTime } from './loop';
 
 let mockTime = 0;
-jest.mock('./dom', () => ({
+jest.mock('../dom', () => ({
   rAF: (callback: FrameRequestCallback) => {
     mockTime += 1000 / 60;
     setTimeout(() => callback(mockTime), 1000 / 60);

--- a/src/lib/game/loop.test.ts
+++ b/src/lib/game/loop.test.ts
@@ -1,33 +1,36 @@
-import loop, { stepTime } from '@fartts/lib/game/loop';
+import loop, { stepTime } from './loop';
 
 let mockTime = 0;
-jest.mock('@fartts/lib/dom', () => ({
+jest.mock('./dom', () => ({
   rAF: (callback: FrameRequestCallback) => {
     mockTime += 1000 / 60;
     setTimeout(() => callback(mockTime), 1000 / 60);
   },
   cAF: (frameId: number) => clearTimeout(frameId),
 }));
+
 jest.useFakeTimers();
 
-test('loop', () => {
-  const update = jest.fn();
-  const render = jest.fn();
-  const { start, stop } = loop(update, render);
+describe('@fartts/lib/loop', () => {
+  test('update and render', () => {
+    const update = jest.fn();
+    const render = jest.fn();
+    const { start, stop } = loop(update, render);
 
-  // multiple calls have no effect
-  start();
-  start();
+    // multiple calls have no effect
+    start();
+    start();
 
-  jest.advanceTimersByTime(stepTime * 3);
+    jest.advanceTimersByTime(stepTime * 3);
 
-  // multiple calls have no effect
-  stop();
-  stop();
+    // multiple calls have no effect
+    stop();
+    stop();
 
-  expect(update).toHaveBeenCalledTimes(1);
-  expect(update).toHaveBeenCalledWith(expect.any(Number), stepTime);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(expect.any(Number), stepTime);
 
-  expect(render).toHaveBeenCalledTimes(3);
-  expect(render).toHaveBeenCalledWith(expect.any(Number));
+    expect(render).toHaveBeenCalledTimes(3);
+    expect(render).toHaveBeenCalledWith(expect.any(Number));
+  });
 });

--- a/src/lib/game/loop.ts
+++ b/src/lib/game/loop.ts
@@ -1,5 +1,5 @@
-import { rAF, cAF } from './dom';
-import { min } from './math';
+import { rAF, cAF } from '../dom';
+import { min } from '../math';
 
 type UpdateFunction = (t: number, dt: number) => void;
 type RenderFunction = (lag: number) => void;

--- a/src/lib/game/loop.ts
+++ b/src/lib/game/loop.ts
@@ -1,5 +1,5 @@
-import { rAF, cAF } from '@fartts/lib/dom';
-import { min } from '@fartts/lib/math';
+import { rAF, cAF } from './dom';
+import { min } from './math';
 
 type UpdateFunction = (t: number, dt: number) => void;
 type RenderFunction = (lag: number) => void;

--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -7,7 +7,7 @@ import {
   tri,
   π,
   ππ,
-} from '@fartts/lib/math';
+} from './math';
 
 describe('@fartts/lib/math', () => {
   test('lerp', () => {

--- a/src/lib/step.test.ts
+++ b/src/lib/step.test.ts
@@ -1,5 +1,5 @@
-import { cos, sin } from '@fartts/lib/math';
-import { step, cosStep, sinStep, sawStep, triStep } from '@fartts/lib/step';
+import { cos, sin } from './math';
+import { step, cosStep, sinStep, sawStep, triStep } from './step';
 
 // just to keep the tables below consice when testing defaults
 const u = undefined;

--- a/src/lib/step.ts
+++ b/src/lib/step.ts
@@ -1,5 +1,5 @@
-import { cos, floor, saw, sin, tri } from '@fartts/lib/math';
-import { wave, TrigFunction, WaveFunction } from '@fartts/lib/wave';
+import { cos, floor, saw, sin, tri } from './math';
+import { wave, TrigFunction, WaveFunction } from './wave';
 
 /**
  * ## step

--- a/src/lib/util/__snapshots__/resize.test.ts.snap
+++ b/src/lib/util/__snapshots__/resize.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`resize [300, 150] to [391, 291] at dpr: undefined 1`] = `
+exports[`@fartts/lib/util/resize resize [300, 150] to [391, 291] at dpr: undefined 1`] = `
 Object {
   "height": 30,
   "style": Object {
@@ -11,7 +11,7 @@ Object {
 }
 `;
 
-exports[`resize [300, 150] to [715, 475] at dpr: 1 1`] = `
+exports[`@fartts/lib/util/resize resize [300, 150] to [715, 475] at dpr: 1 1`] = `
 Object {
   "height": 48,
   "style": Object {
@@ -22,7 +22,7 @@ Object {
 }
 `;
 
-exports[`resize [300, 150] to [800, 450] at dpr: 2 1`] = `
+exports[`@fartts/lib/util/resize resize [300, 150] to [800, 450] at dpr: 2 1`] = `
 Object {
   "height": 90,
   "style": Object {
@@ -33,7 +33,7 @@ Object {
 }
 `;
 
-exports[`resize [300, 150] to [959, 539] at dpr: 3 1`] = `
+exports[`@fartts/lib/util/resize resize [300, 150] to [959, 539] at dpr: 3 1`] = `
 Object {
   "height": 162,
   "style": Object {

--- a/src/lib/util/resize.test.ts
+++ b/src/lib/util/resize.test.ts
@@ -1,34 +1,36 @@
-import resize from '@fartts/lib/util/resize';
+import resize from './resize';
 
-test.each`
-  w      | h      | cw     | ch     | dpr
-  ${300} | ${150} | ${391} | ${291} | ${undefined}
-  ${300} | ${150} | ${715} | ${475} | ${1}
-  ${300} | ${150} | ${800} | ${450} | ${2}
-  ${300} | ${150} | ${959} | ${539} | ${3}
-`('resize [$w, $h] to [$cw, $ch] at dpr: $dpr', ({ w, h, cw, ch, dpr }) => {
-  const mockCanvas = {
-    width: w,
-    height: h,
-    style: { width: `${w}px`, height: `${h}px` },
-  } as HTMLCanvasElement;
+describe('@fartts/lib/util/resize', () => {
+  test.each`
+    w      | h      | cw     | ch     | dpr
+    ${300} | ${150} | ${391} | ${291} | ${undefined}
+    ${300} | ${150} | ${715} | ${475} | ${1}
+    ${300} | ${150} | ${800} | ${450} | ${2}
+    ${300} | ${150} | ${959} | ${539} | ${3}
+  `('resize [$w, $h] to [$cw, $ch] at dpr: $dpr', ({ w, h, cw, ch, dpr }) => {
+    const mockCanvas = {
+      width: w,
+      height: h,
+      style: { width: `${w}px`, height: `${h}px` },
+    } as HTMLCanvasElement;
 
-  const mockMain = { clientWidth: cw, clientHeight: ch } as HTMLMainElement;
+    const mockMain = { clientWidth: cw, clientHeight: ch } as HTMLMainElement;
 
-  Object.defineProperty(window, 'devicePixelRatio', {
-    writable: true,
-    value: dpr,
+    Object.defineProperty(window, 'devicePixelRatio', {
+      writable: true,
+      value: dpr,
+    });
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(resize(mockCanvas, mockMain)).toBe(true);
+    expect(resize(mockCanvas, mockMain)).toBe(false);
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(resize(mockCanvas, mockMain)).toBe(true);
+    expect(resize(mockCanvas, mockMain)).toBe(false);
+
+    expect(mockCanvas).toMatchSnapshot();
   });
-
-  window.dispatchEvent(new Event('resize'));
-
-  expect(resize(mockCanvas, mockMain)).toBe(true);
-  expect(resize(mockCanvas, mockMain)).toBe(false);
-
-  window.dispatchEvent(new Event('resize'));
-
-  expect(resize(mockCanvas, mockMain)).toBe(true);
-  expect(resize(mockCanvas, mockMain)).toBe(false);
-
-  expect(mockCanvas).toMatchSnapshot();
 });

--- a/src/lib/util/resize.ts
+++ b/src/lib/util/resize.ts
@@ -1,4 +1,4 @@
-import { on } from '@fartts/lib/dom';
+import { on } from '../dom';
 
 const { isInteger } = Number;
 

--- a/src/lib/vec/factories.test.ts
+++ b/src/lib/vec/factories.test.ts
@@ -1,5 +1,5 @@
-import { vec2, vec3, vec4 } from '@fartts/lib/vec/factories';
-import { toArray } from '@fartts/lib/vec/util';
+import { vec2, vec3, vec4 } from './factories';
+import { toArray } from './util';
 
 describe('@fartts/lib/vec/factories', () => {
   test.each`

--- a/src/lib/vec/factories.ts
+++ b/src/lib/vec/factories.ts
@@ -1,12 +1,7 @@
-import Vector from '@fartts/lib/vec';
-import { Components, Factory, Vec2, Vec3, Vec4 } from '@fartts/lib/vec/types';
-import {
-  toArray,
-  validateKeys,
-  validateRange,
-  Validates,
-} from '@fartts/lib/vec/util';
-import { swizzledKeys, indicesByKey } from '@fartts/lib/vec/util/keys';
+import Vector from '.';
+import { Components, Factory, Vec2, Vec3, Vec4 } from './types';
+import { toArray, validateKeys, validateRange, Validates } from './util';
+import { swizzledKeys, indicesByKey } from './util/keys';
 
 const { get, set } = Reflect;
 

--- a/src/lib/vec/index.test.ts
+++ b/src/lib/vec/index.test.ts
@@ -1,6 +1,6 @@
-import Vector from '@fartts/lib/vec';
-import { vec2, vec3, vec4 } from '@fartts/lib/vec/factories';
-import { sqrt, hypot, toRadians, π } from '@fartts/lib/math';
+import Vector from '.';
+import { vec2, vec3, vec4 } from './factories';
+import { sqrt, hypot, toRadians, π } from '../math';
 
 describe('@fartts/lib/vec', () => {
   const v2 = vec2(2, 2);

--- a/src/lib/vec/index.ts
+++ b/src/lib/vec/index.ts
@@ -1,6 +1,6 @@
-import { dot, magnitude, direction } from '@fartts/lib/vec/math';
-import { Components } from '@fartts/lib/vec/types';
-import { toArray } from '@fartts/lib/vec/util';
+import { dot, magnitude, direction } from './math';
+import { Components } from './types';
+import { toArray } from './util';
 
 /**
  * # Vector

--- a/src/lib/vec/math.test.ts
+++ b/src/lib/vec/math.test.ts
@@ -11,7 +11,7 @@ import {
   normalize,
   lerp,
 } from './math';
-import { hypot, sqrt, π, toRadians } from './math';
+import { hypot, sqrt, π, toRadians } from '../math';
 
 describe('@fartts/lib/vec/math', () => {
   const v2 = vec2(2, 2);

--- a/src/lib/vec/math.test.ts
+++ b/src/lib/vec/math.test.ts
@@ -1,4 +1,4 @@
-import { vec2, vec3, vec4, getLeft, getZeros } from '@fartts/lib/vec/factories';
+import { vec2, vec3, vec4, getLeft, getZeros } from './factories';
 import {
   dot,
   magnitude,
@@ -10,8 +10,8 @@ import {
   div,
   normalize,
   lerp,
-} from '@fartts/lib/vec/math';
-import { hypot, sqrt, π, toRadians } from '@fartts/lib/math';
+} from './math';
+import { hypot, sqrt, π, toRadians } from './math';
 
 describe('@fartts/lib/vec/math', () => {
   const v2 = vec2(2, 2);

--- a/src/lib/vec/math.ts
+++ b/src/lib/vec/math.ts
@@ -1,8 +1,8 @@
-import Vector from '@fartts/lib/vec';
-import { getFactory, getLeft } from '@fartts/lib/vec/factories';
-import { acos, hypot, lerp as slerp } from '@fartts/lib/math';
-import { validateOperands } from '@fartts/lib/vec/util';
-import { Vec2, Vec3, Vec4 } from '@fartts/lib/vec/types';
+import Vector from '.';
+import { getFactory, getLeft } from './factories';
+import { acos, hypot, lerp as slerp } from '../math';
+import { validateOperands } from './util';
+import { Vec2, Vec3, Vec4 } from './types';
 
 /**
  * ## dot

--- a/src/lib/vec/types/index.ts
+++ b/src/lib/vec/types/index.ts
@@ -1,8 +1,8 @@
-import Vector from '.';
+import Vector from '..';
 
-import { Vec2D1, Vec2D2, Vec2D3, Vec2D4 } from './types/vec2';
-import { Vec3D1, Vec3D2, Vec3D3, Vec3D4 } from './types/vec3';
-import { Vec4D1, Vec4D2, Vec4D3, Vec4D4 } from './types/vec4';
+import { Vec2D1, Vec2D2, Vec2D3, Vec2D4 } from './vec2';
+import { Vec3D1, Vec3D2, Vec3D3, Vec3D4 } from './vec3';
+import { Vec4D1, Vec4D2, Vec4D3, Vec4D4 } from './vec4';
 
 export type Component = number | number[] | Vector;
 export type Components = Component[];

--- a/src/lib/vec/types/index.ts
+++ b/src/lib/vec/types/index.ts
@@ -1,8 +1,8 @@
-import Vector from '@fartts/lib/vec';
+import Vector from '.';
 
-import { Vec2D1, Vec2D2, Vec2D3, Vec2D4 } from '@fartts/lib/vec/types/vec2';
-import { Vec3D1, Vec3D2, Vec3D3, Vec3D4 } from '@fartts/lib/vec/types/vec3';
-import { Vec4D1, Vec4D2, Vec4D3, Vec4D4 } from '@fartts/lib/vec/types/vec4';
+import { Vec2D1, Vec2D2, Vec2D3, Vec2D4 } from './types/vec2';
+import { Vec3D1, Vec3D2, Vec3D3, Vec3D4 } from './types/vec3';
+import { Vec4D1, Vec4D2, Vec4D3, Vec4D4 } from './types/vec4';
 
 export type Component = number | number[] | Vector;
 export type Components = Component[];

--- a/src/lib/vec/types/vec2/index.ts
+++ b/src/lib/vec/types/vec2/index.ts
@@ -1,6 +1,6 @@
-import { Rg2, Rg3, Rg4 } from './vec2/rg';
-import { St2, St3, St4 } from './vec2/st';
-import { Xy2, Xy3, Xy4 } from './vec2/xy';
+import { Rg2, Rg3, Rg4 } from './rg';
+import { St2, St3, St4 } from './st';
+import { Xy2, Xy3, Xy4 } from './xy';
 
 export type Vec2D1 = 'g' | 't' | 'y';
 export type Vec2D2 = Rg2 | St2 | Xy2;

--- a/src/lib/vec/types/vec2/index.ts
+++ b/src/lib/vec/types/vec2/index.ts
@@ -1,6 +1,6 @@
-import { Rg2, Rg3, Rg4 } from '@fartts/lib/vec/types/vec2/rg';
-import { St2, St3, St4 } from '@fartts/lib/vec/types/vec2/st';
-import { Xy2, Xy3, Xy4 } from '@fartts/lib/vec/types/vec2/xy';
+import { Rg2, Rg3, Rg4 } from './vec2/rg';
+import { St2, St3, St4 } from './vec2/st';
+import { Xy2, Xy3, Xy4 } from './vec2/xy';
 
 export type Vec2D1 = 'g' | 't' | 'y';
 export type Vec2D2 = Rg2 | St2 | Xy2;

--- a/src/lib/vec/types/vec3/index.ts
+++ b/src/lib/vec/types/vec3/index.ts
@@ -1,6 +1,6 @@
-import { Rgb2, Rgb3, Rgb4 } from './vec3/rgb';
-import { Stp2, Stp3, Stp4 } from './vec3/stp';
-import { Xyz2, Xyz3, Xyz4 } from './vec3/xyz';
+import { Rgb2, Rgb3, Rgb4 } from './rgb';
+import { Stp2, Stp3, Stp4 } from './stp';
+import { Xyz2, Xyz3, Xyz4 } from './xyz';
 
 export type Vec3D1 = 'b' | 'p' | 'z';
 export type Vec3D2 = Rgb2 | Stp2 | Xyz2;

--- a/src/lib/vec/types/vec3/index.ts
+++ b/src/lib/vec/types/vec3/index.ts
@@ -1,6 +1,6 @@
-import { Rgb2, Rgb3, Rgb4 } from '@fartts/lib/vec/types/vec3/rgb';
-import { Stp2, Stp3, Stp4 } from '@fartts/lib/vec/types/vec3/stp';
-import { Xyz2, Xyz3, Xyz4 } from '@fartts/lib/vec/types/vec3/xyz';
+import { Rgb2, Rgb3, Rgb4 } from './vec3/rgb';
+import { Stp2, Stp3, Stp4 } from './vec3/stp';
+import { Xyz2, Xyz3, Xyz4 } from './vec3/xyz';
 
 export type Vec3D1 = 'b' | 'p' | 'z';
 export type Vec3D2 = Rgb2 | Stp2 | Xyz2;

--- a/src/lib/vec/types/vec4/index.ts
+++ b/src/lib/vec/types/vec4/index.ts
@@ -1,6 +1,6 @@
-import { Rgba2, Rgba3, Rgba4 } from '@fartts/lib/vec/types/vec4/rgba';
-import { Stpq2, Stpq3, Stpq4 } from '@fartts/lib/vec/types/vec4/stpq';
-import { Xyzw2, Xyzw3, Xyzw4 } from '@fartts/lib/vec/types/vec4/xyzw';
+import { Rgba2, Rgba3, Rgba4 } from './vec4/rgba';
+import { Stpq2, Stpq3, Stpq4 } from './vec4/stpq';
+import { Xyzw2, Xyzw3, Xyzw4 } from './vec4/xyzw';
 
 export type Vec4D1 = 'a' | 'q' | 'w';
 export type Vec4D2 = Rgba2 | Stpq2 | Xyzw2;

--- a/src/lib/vec/types/vec4/index.ts
+++ b/src/lib/vec/types/vec4/index.ts
@@ -1,6 +1,6 @@
-import { Rgba2, Rgba3, Rgba4 } from './vec4/rgba';
-import { Stpq2, Stpq3, Stpq4 } from './vec4/stpq';
-import { Xyzw2, Xyzw3, Xyzw4 } from './vec4/xyzw';
+import { Rgba2, Rgba3, Rgba4 } from './rgba';
+import { Stpq2, Stpq3, Stpq4 } from './stpq';
+import { Xyzw2, Xyzw3, Xyzw4 } from './xyzw';
 
 export type Vec4D1 = 'a' | 'q' | 'w';
 export type Vec4D2 = Rgba2 | Stpq2 | Xyzw2;

--- a/src/lib/vec/util/index.test.ts
+++ b/src/lib/vec/util/index.test.ts
@@ -1,10 +1,5 @@
-import { vec2, vec3, vec4 } from '@fartts/lib/vec/factories';
-import {
-  toArray,
-  validateKeys,
-  validateRange,
-  Validates,
-} from '@fartts/lib/vec/util';
+import { vec2, vec3, vec4 } from '../factories';
+import { toArray, validateKeys, validateRange, Validates } from '.';
 
 describe('@fartts/lib/vec/util', () => {
   test.each`

--- a/src/lib/vec/util/index.ts
+++ b/src/lib/vec/util/index.ts
@@ -1,5 +1,5 @@
-import Vector from '@fartts/lib/vec';
-import { Component } from '@fartts/lib/vec/types';
+import Vector from '..';
+import { Component } from '../types';
 
 /**
  * ## toArray

--- a/src/lib/vec/util/keys.test.ts
+++ b/src/lib/vec/util/keys.test.ts
@@ -1,4 +1,4 @@
-import { swizzledKeys, indicesByKey } from '@fartts/lib/vec/util/keys';
+import { swizzledKeys, indicesByKey } from './keys';
 
 describe('@fartts/lib/vec/util/keys', () => {
   test('config', () => {

--- a/src/lib/wave.test.ts
+++ b/src/lib/wave.test.ts
@@ -1,5 +1,5 @@
-import { cos, sin } from '@fartts/lib/math';
-import { wave, cosWave, sinWave, sawWave, triWave } from '@fartts/lib/wave';
+import { cos, sin } from './math';
+import { wave, cosWave, sinWave, sawWave, triWave } from './wave';
 
 // just to keep the tables below consice when testing defaults
 const u = undefined;

--- a/src/lib/wave.ts
+++ b/src/lib/wave.ts
@@ -1,4 +1,4 @@
-import { cos, saw, sin, tri, ππ } from '@fartts/lib/math';
+import { cos, saw, sin, tri, ππ } from './math';
 
 export type TrigFunction = (radians: number) => number;
 export type WaveFunction = (timestamp: number) => number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "declaration": false,
     "esModuleInterop": true,
     "lib": [
@@ -16,14 +15,6 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noUnusedLocals": true,
-    "paths": {
-      "*": [
-        "node_modules/*"
-      ],
-      "@fartts/lib/*": [
-        "src/lib/*"
-      ]
-    },
     "strict": true,
     "target": "es2015",
     "types": [


### PR DESCRIPTION
Removes custom path setup from `tsconfig.json` so that I can hopefully merge #202 (https://github.com/fathyb/parcel-plugin-typescript doesn't work with Babel 7 it looks like).