### PR TITLE
Fix grey flash on click

### DIFF
--- a/src/lab/10-song-trees/entry.ts
+++ b/src/lab/10-song-trees/entry.ts
@@ -9,6 +9,8 @@ import Tree from './tree/constants/tree';
 import { gradient } from './tree/gradient';
 import { lerp, min, random } from '../../lib/core/math';
 
+document.addEventListener('touchstart', () => true, true);
+
 const m = el('main') as HTMLMainElement;
 
 const c = el('canvas') as HTMLCanvasElement;

--- a/src/lab/10-song-trees/style.css
+++ b/src/lab/10-song-trees/style.css
@@ -19,6 +19,7 @@ body,
 main,
 canvas {
   cursor: pointer;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 canvas {


### PR DESCRIPTION
See: https://css-tricks.com/snippets/css/remove-gray-highlight-when-tapping-links-in-mobile-safari/