### PR TITLE
Fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ members = [
   "src/lab/12-wasm-particles",
   "src/lab/13-game-of-life",
 ]
+
+[profile.release]
+# optimize for size
+# @see: https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections
+opt-level = "s"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jest": "24.8.0",
     "lodash": "4.17.11",
     "parcel-bundler": "1.12.3",
-    "parcel-plugin-wasm-pack": "2.0.2",
+    "parcel-plugin-wasm-pack": "3.0.0",
     "prettier": "1.17.1",
     "semantic-release": "15.13.12",
     "semantic-release-github-pr": "https://github.com/mysterycommand/semantic-release-github-pr.git#fix/34-and-35",

--- a/src/lab/13-game-of-life/Cargo.toml
+++ b/src/lab/13-game-of-life/Cargo.toml
@@ -12,12 +12,12 @@ default = ["console_error_panic_hook", "wee_alloc"]
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.6", optional = true }
-js-sys = "0.3.20"
-wasm-bindgen = "0.2.43"
+js-sys = "0.3.22"
+wasm-bindgen = "0.2.45"
 wee_alloc = { version = "0.4.4", optional = true }
 
 [dependencies.web-sys]
-version = "0.3.20"
+version = "0.3.22"
 features = [
   "console",
   "CanvasRenderingContext2d",
@@ -33,9 +33,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.43"
-
-[profile.release]
-# optimize for size
-# @see: https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections
-opt-level = "s"
+wasm-bindgen-test = "0.2.45"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7086,10 +7086,10 @@ parcel-bundler@1.12.3:
     v8-compile-cache "^2.0.0"
     ws "^5.1.1"
 
-parcel-plugin-wasm-pack@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/parcel-plugin-wasm-pack/-/parcel-plugin-wasm-pack-2.0.2.tgz#eb30b29f160294a9cf82f03cf47604f3dc3e623a"
-  integrity sha512-b0JG7Z8cuGc5sahPmrwKR5Ef4ZTCzANVoSOtWHkcyMObJx7l1qRSbg75PfCKHYpVV3wORNvX08nac58DoEdloA==
+parcel-plugin-wasm-pack@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/parcel-plugin-wasm-pack/-/parcel-plugin-wasm-pack-3.0.0.tgz#10a47a669f66d1159c588d862c9e374e2ede6850"
+  integrity sha512-cJ3zIVIA9OkZuuv+vh8+iQtFwgP/K2rv7DOiYZGea1owh7GhbwFmFCIfDf+d5rf/cpu8byF2jOCtTaRqlVN0xQ==
   dependencies:
     "@iarna/toml" "2.2.3"
     "@parcel/fs" "1.11.0"


### PR DESCRIPTION
Bumps some deps, most notably `parcel-plugin-wasm-pack` to `@3.0.0` to fix the object exposed by the initializer. Also moves the `profiles` declaration to the root `Cargo.toml`. 