### PR TITLE
Fix package names

### DIFF
--- a/src/lab/11-rust-wasm/Cargo.toml
+++ b/src/lab/11-rust-wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "11-rust-wasm"
+name = "rust-wasm"
 version = "0.1.0"
 authors = ["Matt Hayes <matt@mysterycommand.com>"]
 edition = "2018"

--- a/src/lab/12-wasm-particles/Cargo.toml
+++ b/src/lab/12-wasm-particles/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "12-wasm-particles"
+name = "wasm-particles"
 version = "0.1.0"
 authors = ["Matt Hayes <matt@mysterycommand.com>"]
 edition = "2018"


### PR DESCRIPTION
```
the name `12-wasm-particles` cannot be used as a package name, the name cannot start with a digit
```
(not sure how other builds passed)